### PR TITLE
Automatically enable tox coloring on github actions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 repos:
-  - repo: https://github.com/pre-commit/mirrors-prettier
+  - repo: https://github.com/rbubley/mirrors-prettier
     # keep it before markdownlint and eslint
-    rev: "v4.0.0-alpha.8"
+    rev: "v3.6.1"
     hooks:
       - id: prettier
   - repo: https://github.com/pre-commit/pre-commit-hooks.git

--- a/README.md
+++ b/README.md
@@ -56,3 +56,14 @@ system dependencies specific to a single tox environment if they wish.
 
 To disable bindep feature, you can define `TOX_EXTRA_BINDEP=0` in your
 environment.
+
+## Improves colored output on CI
+
+Multiple tools, including tox and pre-commit fail to property use coloring
+when run in a CI evironment like Github Actions. This plugin will inject
+additional environment variables in order to ensure that the tool output
+remains colored.
+
+It should be noted that this happens only if these variables are not already
+defined by the user. This feature should reduce the need of adding extra
+environment variables to your pipelines.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,7 @@ repository = "https://github.com/tox-dev/tox-extra"
 source = ["src"]
 
 [tool.coverage.report]
+exclude_also = ["pragma: no cover", "if TYPE_CHECKING:"]
 fail_under = 92.0
 include = ["src/*"]
 omit = [".tox/*/lib/python*/site-packages/*", "src/*/_version.py"]
@@ -205,7 +206,7 @@ commands = [
 description = "Run tests"
 extras = ["test"]
 package = "editable"
-pass_env = ["SSH_AUTH_SOCK"]
+pass_env = ["ANSIBLE_FORCE_COLOR", "CI", "FORCE_COLOR", "GITHUB_*", "MYPY_*", "PRE_COMMIT*", "PY_COLORS", "SSH_AUTH_SOCK", "TERM"]
 requires = ["tox-uv"]
 set_env = {COVERAGE_FILE = "{env:COVERAGE_FILE:{toxworkdir}/.coverage.{envname}}", COVERAGE_PROCESS_START = "{toxinidir}/pyproject.toml", GIT_AUTHOR_EMAIL = "noreply@example.com", GIT_AUTHOR_NAME = "John Doe", GIT_COMMITTER_EMAIL = "noreply@example.com", GIT_COMMITTER_NAME = "John Doe", PIP_DISABLE_PIP_VERSION_CHECK = "1", PYTHONWARNINGS = "error"}
 skip_install = false

--- a/src/tox_extra/hooks.py
+++ b/src/tox_extra/hooks.py
@@ -7,7 +7,7 @@ import os
 import pathlib
 import shutil
 import sys
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, TextIO
 
 import git
 from tox.plugin import impl
@@ -33,9 +33,54 @@ ERROR_MSG_GIT_DIRTY = (
     "::error title=tox-extra detected git dirty status:: " + WARNING_MSG_GIT_DIRTY
 )
 
-# Change the color of stderr from default red to a dimmed grey
-if "TOX_STDERR_COLOR" not in os.environ:
-    os.environ["TOX_STDERR_COLOR"] = "LIGHTBLACK_EX"
+
+# Based on Ansible implementation
+def to_bool(value: str | bool | None) -> bool:  # pragma: no cover  # noqa: FBT001
+    """Return a bool for the arg."""
+    if value is None or isinstance(value, bool):
+        return bool(value)
+    if isinstance(value, str):
+        value = value.lower()
+    return value in ("yes", "on", "1", "true", 1)
+
+
+def should_do_markup(stream: TextIO = sys.stdout) -> bool:  # pragma: no cover
+    """Decide about use of ANSI colors."""
+    py_colors = None
+
+    # https://xkcd.com/927/
+    for env_var in [
+        "PY_COLORS",
+        "CLICOLOR",
+        "FORCE_COLOR",
+        "TOX_COLORED",
+        "GITHUB_ACTIONS",  # they support ANSI
+    ]:
+        value = os.environ.get(env_var, None)
+        if value is not None:
+            py_colors = to_bool(value)
+            break
+
+    # If deliberately disabled colors
+    if os.environ.get("NO_COLOR", None):
+        return False
+
+    # User configuration requested colors
+    if py_colors is not None:
+        return to_bool(py_colors)
+
+    term = os.environ.get("TERM", "")
+    if "xterm" in term:
+        return True
+
+    if term == "dumb":
+        return False
+
+    # Use tty detection logic as last resort because there are numerous
+    # factors that can make isatty return a misleading value, including:
+    # - stdin.isatty() is the only one returning true, even on a real terminal
+    # - stderr returning false if user uses a error stream coloring solution
+    return stream.isatty()
 
 
 def is_git_dirty(path: str) -> bool:
@@ -109,3 +154,21 @@ def tox_after_run_commands(
         if os.environ.get("CI") == "true":
             raise Fail(ERROR_MSG_GIT_DIRTY)
         logger.warning(WARNING_MSG_GIT_DIRTY)
+
+
+if should_do_markup():
+    # Workaround for tools that do not naturally detect colors in CI system
+    # like Github Actions. Still, when already defined we will not add them.
+    overrides = {
+        "ANSIBLE_FORCE_COLOR": "1",
+        "COLOR": "yes",
+        "FORCE_COLOR": "1",
+        "MYPY_FORCE_COLOR": "1",
+        "PRE_COMMIT_COLOR": "always",
+        "PY_COLORS": "1",
+        "TOX_COLORED": "yes",
+        "TOX_STDERR_COLOR": "LIGHTBLACK_EX",  # stderr in grey instead of red
+    }
+    for k, v in overrides.items():
+        if k not in os.environ:
+            os.environ[k] = v


### PR DESCRIPTION
As tox is not able to automatically use coloring on github actions, we now detect them and add the needed option dynamically.

This change will spare the need to define extra variables in workflows like FORCE_COLOR=1 to enable coloring.